### PR TITLE
Added Fetch in Bruno button to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,12 @@ parsing your documents to uploading embeddings—without restarting at every lit
      - Check the processing in Application Insights:
        ![App Insights](assets/application_insights.png)
      - Or view the function app’s invocations by selecting the `index_event_grid` function and switching to the "Invocations" tab.
-   - **Accessing Search:** Use the AI Search portal or the provided [Bruno collection](https://www.usebruno.com/) in the `/http` folder. (Don’t forget to update the `host` variable in the collection settings with your function app name.)
+   - **Accessing Search:** Use the AI Search portal or the provided [Bruno collection](https://www.usebruno.com/) in the `/http` folder.
+      You can also clone/import the collection just by clicking the button below:
+
+     [<img src="https://fetch.usebruno.com/button.svg" alt="Fetch in Bruno" style="width: 130px; height: 30px;" width="128" height="32">](https://fetch.usebruno.com?url=https%3A%2F%2Fgithub.com%2FAzure-Samples%2Findexadillo "target=_blank rel=noopener noreferrer")
+
+      (Don’t forget to update the `host` variable in the collection settings with your function app name.)
    - **Reindexing:** Trigger a full reindex via the `/index` endpoint. This creates a new index (defaulted to `other-index`, can
      be changed in the parameters) for the blobs. You can adjust the prefixes to index specific folders, and the endpoint returns an ID to track progress
      via `/status/:id`.


### PR DESCRIPTION
## Purpose
This adds a Fetch in Bruno button to the README so that users can simply clone it with a click. That also means they'll be able to pull changes down easily from the Bruno app. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->